### PR TITLE
Removes ore gen

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -1,6 +1,6 @@
 /datum/map_generator/cave_generator/icemoon
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/snow/icemoon = 19, /turf/open/misc/ice/icemoon = 1)
-	weighted_closed_turf_types = list(/turf/closed/mineral/random/snow = 1)
+	weighted_closed_turf_types = list(/turf/closed/mineral/snowmountain/icemoon = 1)
 
 
 	weighted_mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/wolf = 50, /obj/structure/spawner/ice_moon = 3, \
@@ -28,7 +28,7 @@
 /datum/map_generator/cave_generator/icemoon/surface/noruins //use this for when you don't want ruins to spawn in a certain area
 
 /datum/map_generator/cave_generator/icemoon/deep
-	weighted_closed_turf_types = list(/turf/closed/mineral/random/snow/underground = 1)
+	weighted_closed_turf_types = list(/turf/closed/mineral/snowmountain/icemoon = 1)
 	weighted_mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/ice_demon = 100, /obj/structure/spawner/ice_moon/demonic_portal = 6, \
 						  /mob/living/simple_animal/hostile/asteroid/ice_whelp = 60, /obj/structure/spawner/ice_moon/demonic_portal/ice_whelp = 6, \
 						  /mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow = 100, /obj/structure/spawner/ice_moon/demonic_portal/snowlegion = 6, \

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -1,6 +1,6 @@
 /datum/map_generator/cave_generator/lavaland
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/basalt/lava_land_surface = 1)
-	weighted_closed_turf_types = list(/turf/closed/mineral/random/volcanic = 1)
+	weighted_closed_turf_types = list(/turf/closed/mineral/volcanic/lava_land_surface = 1)
 
 	weighted_mob_spawn_list = list(
 		/mob/living/basic/mining/goliath/random = 50,
@@ -42,4 +42,4 @@
 
 /datum/map_generator/cave_generator/lavaland/ruin_version
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/basalt/lava_land_surface/no_ruins = 1)
-	weighted_closed_turf_types = list(/turf/closed/mineral/random/volcanic/do_not_chasm = 1)
+	weighted_closed_turf_types = list(/turf/closed/mineral/volcanic/lava_land_surface/do_not_chasm = 1)

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -7,7 +7,7 @@
 	ruin_type = ZTRAIT_ICE_RUINS
 	default_area = /area/icemoon/surface/outdoors/unexplored
 	has_ceiling = TRUE
-	ceiling_turf = /turf/closed/mineral/random/snow/do_not_chasm
+	ceiling_turf = /turf/closed/mineral/snowmountain/do_not_chasm
 	ceiling_baseturfs = list(/turf/open/misc/asteroid/snow/icemoon/do_not_chasm)
 
 // above ground only

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -334,12 +334,6 @@
 		/turf/closed/mineral/gibtonite/volcanic = 4,
 	)
 
-/// A turf that can't we can't build openspace chasms on or spawn ruins in.
-/turf/closed/mineral/random/volcanic/do_not_chasm
-	turf_type = /turf/open/misc/asteroid/basalt/lava_land_surface/no_ruins
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface/no_ruins
-	turf_flags = NO_RUINS
-
 /turf/closed/mineral/random/snow
 	name = "snowy mountainside"
 	icon = MAP_SWITCH('icons/turf/walls/mountain_wall.dmi', 'icons/turf/mining.dmi')
@@ -375,7 +369,7 @@
 	)
 
 /// Near exact same subtype as parent, just used in ruins to prevent other ruins/chasms from spawning on top of it.
-/turf/closed/mineral/random/snow/do_not_chasm
+/turf/closed/mineral/snowmountain/do_not_chasm
 	turf_type = /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
 	baseturfs = /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
 	turf_flags = NO_RUINS

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -185,6 +185,10 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 /turf/open/misc/asteroid/basalt/lava_land_surface/no_ruins
 	turf_flags = NO_RUINS
 
+/// A turf that can't we can't build openspace chasms on or spawn ruins in.
+/turf/closed/mineral/volcanic/lava_land_surface/do_not_chasm
+	turf_flags = NO_RUINS
+
 /turf/open/misc/asteroid/lowpressure
 	initial_gas_mix = OPENTURF_LOW_PRESSURE
 	baseturfs = /turf/open/misc/asteroid/lowpressure

--- a/code/modules/procedural_mapping/mapGenerators/lavaland.dm
+++ b/code/modules/procedural_mapping/mapGenerators/lavaland.dm
@@ -3,10 +3,10 @@
 	spawnableTurfs = list(/turf/open/misc/asteroid/basalt/lava_land_surface = 100)
 
 /datum/map_generator_module/bottom_layer/lavaland_mineral
-	spawnableTurfs = list(/turf/closed/mineral/random/volcanic = 100)
+	spawnableTurfs = list(/turf/closed/mineral/volcanic = 100)
 
 /datum/map_generator_module/bottom_layer/lavaland_mineral/dense
-	spawnableTurfs = list(/turf/closed/mineral/random/high_chance/volcanic = 100)
+	spawnableTurfs = list(/turf/closed/mineral/volcanic = 100)
 
 /datum/map_generator_module/splatter_layer/lavaland_monsters
 	spawnableTurfs = list()


### PR DESCRIPTION
Removes the oregen from random terrain gen

Also uhh, for icebox: closed snow walls with minerals spawn as their "rocky" variant, which don't appear anymore due to lack of ore

And uhhhh there's still stuff like labor and some ruins spawning with guaranteed mineral ores. Want me to excise them? It's gonna be a huge dif though