### PR TITLE
Slightly unfucks space heater cell handling

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -89,6 +89,11 @@
 		cell = null
 	return ..()
 
+/obj/machinery/space_heater/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == cell)
+		cell = null
+
 /obj/machinery/space_heater/examine(mob/user)
 	. = ..()
 	. += "\The [src] is [on ? "on" : "off"], and the hatch is [panel_open ? "open" : "closed"]."
@@ -288,7 +293,6 @@
 		if("eject")
 			if(panel_open && cell)
 				usr.put_in_hands(cell)
-				cell = null
 				. = TRUE
 
 /obj/machinery/space_heater/proc/toggle_power(user)


### PR DESCRIPTION
[Slightly unfucks space heater cell handling](https://github.com/ArcaneMusic/TG-Station-Arcane-Remix/commit/ab7aa7fd2a049dbc360aa492f10a7c947f71ab8b)

Instead of HANGING A HARD REF TO A QDEL'D CELL the space heater now releases it on Exited().
As a bonus, this means the heater will no longer drop a qdeleted cell in to a locker on export due to a fucked up and stupid chain of logic predicated on INSERTING THE CELL INTO ITS COMPONENT PARTS LIST ON DECON WHY. I have left the sincode in because I am too tired to grasp why it's here although I suspect it's just because whoever wrote it hates the love of god

 This should fix the C&D errors